### PR TITLE
Set Vsersion Dynamicly from Git-Tag

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -33,7 +33,7 @@ jobs:
           file: buildbox.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/buildbox:${{ env.GITHUB_REF_SLUG }}
-          build-args: "VERSION=\"-${{ env.GITHUB_REF_SLUG }}\""
+          build-args: "VERSION=\"${{ env.GITHUB_REF_SLUG }}\""
       - name: E2E Runner Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -42,7 +42,7 @@ jobs:
           file: e2e.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/e2e-runner:${{ env.GITHUB_REF_SLUG }}
-          build-args: "VERSION=\"-${{ env.GITHUB_REF_SLUG }}\""
+          build-args: "VERSION=\"${{ env.GITHUB_REF_SLUG }}\""
       - name: List Docker images
         shell: bash
         run: |

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -33,6 +33,7 @@ jobs:
           file: buildbox.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/buildbox:${{ env.GITHUB_REF_SLUG }}
+          build-args: "VERSION=\"-${{ env.GITHUB_REF_SLUG }}\""
       - name: E2E Runner Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -41,6 +42,7 @@ jobs:
           file: e2e.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/e2e-runner:${{ env.GITHUB_REF_SLUG }}
+          build-args: "VERSION=\"-${{ env.GITHUB_REF_SLUG }}\""
       - name: List Docker images
         shell: bash
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,6 +23,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Short SHA
+        id: get_short_sha
+        run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
       - name: Buildbox Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -31,6 +34,7 @@ jobs:
           file: buildbox.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/buildbox:nightly
+          build-args: "VERSION=\"nightly-$SHORT_SHA\""
       - name: E2E Runner Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -39,3 +43,4 @@ jobs:
           file: e2e.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/e2e-runner:nightly
+          build-args: "VERSION=\"nightly-$SHORT_SHA\""

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -33,6 +33,7 @@ jobs:
           file: buildbox.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/buildbox:rc-${{ env.GITHUB_REF_SLUG }}
+          build-args: "VERSION=\"rc-${{ env.GITHUB_REF_SLUG }}\""
       - name: E2E Runner Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -41,3 +42,4 @@ jobs:
           file: e2e.dockerfile
           tags: |
             ghcr.io/${{ github.repository_owner }}/e2e-runner:rc-${{ env.GITHUB_REF_SLUG }}
+          build-args: "VERSION=\"rc-${{ env.GITHUB_REF_SLUG }}\""

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/buildbox:latest
             ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: "VERSION=\"${{ steps.meta.outputs.version }}\""
+
       - name: E2E Runner Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -46,3 +48,4 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/e2e-runner:latest
             ghcr.io/${{ github.repository_owner }}/e2e-runner:${{ steps.meta.outputs.version }}
+          build-args: "VERSION=\"${{ steps.meta.outputs.version }}\""

--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,12 @@
 
 docker build \
   -t ghcr.io/uitsmijter/buildbox \
+  --build-arg VERSION=local \
   -f buildbox.dockerfile \
   .
 
 docker build \
   -t ghcr.io/uitsmijter/e2e-runner \
+  --build-arg VERSION=local \
   -f e2e.dockerfile \
   .

--- a/buildbox.dockerfile
+++ b/buildbox.dockerfile
@@ -2,9 +2,9 @@
 # Uitsmijter Swift Buildbox
 # ----------------------------------------------------------------------------------------
 ARG BASEIMAGE=swift:6.2.0-noble
-ARG VERSION=0.0.0
 
 FROM ${BASEIMAGE} as build
+ARG VERSION=0.0.0
 LABEL maintainer="aus der Technik"
 LABEL Description="Swift Buildbox For Uitsmijter"
 
@@ -27,7 +27,7 @@ RUN apt update -q \
     && rm -rf /var/lib/apt/lists/*; rm -rf /var/cache/apt/*
 
 ADD src/entrypoint-build.sh /entrypoint.sh
-RUN sed -i 's/<VERSION>/${VERSION}/g' /entrypoint.sh
+RUN sed -i "s/<VERSION>/${VERSION}/g" /entrypoint.sh
 
 # Set up a build area
 WORKDIR /build

--- a/buildbox.dockerfile
+++ b/buildbox.dockerfile
@@ -2,6 +2,7 @@
 # Uitsmijter Swift Buildbox
 # ----------------------------------------------------------------------------------------
 ARG BASEIMAGE=swift:6.2.0-noble
+ARG VERSION=0.0.0
 
 FROM ${BASEIMAGE} as build
 LABEL maintainer="aus der Technik"
@@ -26,6 +27,7 @@ RUN apt update -q \
     && rm -rf /var/lib/apt/lists/*; rm -rf /var/cache/apt/*
 
 ADD src/entrypoint-build.sh /entrypoint.sh
+RUN sed -i 's/<VERSION>/${VERSION}/g' /entrypoint.sh
 
 # Set up a build area
 WORKDIR /build

--- a/e2e.dockerfile
+++ b/e2e.dockerfile
@@ -50,5 +50,7 @@ USER root
     npx playwright install
 
 ADD src/entrypoint-test.sh /entrypoint.sh
+RUN sed -i 's/<VERSION>/${VERSION}/g' /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "bash" ]

--- a/e2e.dockerfile
+++ b/e2e.dockerfile
@@ -21,7 +21,7 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
 # E2E TEST RUNTIME
 # ----------------------------------------------------------------------------------------
 FROM node:20-bullseye
-
+ARG VERSION=0.0.0
 LABEL maintainer="aus der Technik"
 LABEL Description="Uitsmijter e2e"
 

--- a/src/entrypoint-build.sh
+++ b/src/entrypoint-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo ""
-echo "Uitsmijter Buildbox 3.0.0 | Swift 6.2.0"
+echo "Uitsmijter Buildbox <VERSION> | Swift 6.2.0"
 echo "------------------------------------------------------------"
 echo "Visit: https://docs.uitsmijter.io"
 echo ""

--- a/src/entrypoint-test.sh
+++ b/src/entrypoint-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo ""
-echo "Uitsmijter TestRunner 3.0.0 | Swift 6.2.0"
+echo "Uitsmijter TestRunner <VERSION> | Swift 6.2.0"
 echo "------------------------------------------------------------"
 echo "Visit: https://docs.uitsmijter.io"
 echo ""


### PR DESCRIPTION
The Buildbox Version 4.0.0 has a label 3.0.0. That is because we forgot to edit the entrypoint.sh. 
To prevent this in the future, we set the Version dynamically. 